### PR TITLE
Update widgets

### DIFF
--- a/config/dwm/scripts/widgets
+++ b/config/dwm/scripts/widgets
@@ -91,6 +91,6 @@ get_title () {
 
 while :; do
   xsetroot -name "$(get_title)"
-  sleep 0.5
+  sleep 1
 done &
 


### PR DESCRIPTION
Some distributions (*cough* Alpine *cough*)  seem to not like sleep integers that aren't whole numbers. Change from sleep 0.5 to sleep 1 to avoid this issue.