### PR TITLE
Update picom.conf

### DIFF
--- a/config/picom/picom.conf
+++ b/config/picom/picom.conf
@@ -1,4 +1,3 @@
-clear-shadow = true;
 shadow = true;
 
 shadow-radius = 10;


### PR DESCRIPTION
Removed clear-shadow = true; as the option is depreciated and newer picom assumes it to be on by default.